### PR TITLE
Problem: provision enroll all ends with an error

### DIFF
--- a/cli/commands/provision.py
+++ b/cli/commands/provision.py
@@ -157,7 +157,7 @@ class EnrollActor(TestSuiteActor):
         ]).run()
 
     def up(self, task, args):
-        self.call(VagrantCommandActor('up'))
+        self.call(VagrantCommandActor('up'), args)
 
     def enroll(self, task, args, argv):
         if 'all' in args.guests:


### PR DESCRIPTION
Python exception

[sssd-test-suite] Exception AttributeError: 'Namespace' object has no attribute 'guests'
[sssd-test-suite] Traceback (most recent call last):
  File "/home/thalman/sssd-test-suite/cli/lib/command.py", line 201, in execute
    self._run_handler(args.func, args, split_argv)
  File "/home/thalman/sssd-test-suite/cli/lib/command.py", line 270, in _run_handler
    handler.run(args, argv)
  File "/home/thalman/sssd-test-suite/cli/commands/provision.py", line 156, in run
    Task('Enroll Machines', self.enroll, args, argv)
  File "/home/thalman/sssd-test-suite/cli/lib/task.py", line 117, in run
    run_tasks()
  File "/home/thalman/sssd-test-suite/cli/lib/task.py", line 115, in run_tasks
    self._run_task_list()
  File "/home/thalman/sssd-test-suite/cli/lib/task.py", line 87, in _run_task_list
    task.run(self)
  File "/home/thalman/sssd-test-suite/cli/lib/task.py", line 40, in run
    self.handler(self, *self.args, **self.kwargs)
  File "/home/thalman/sssd-test-suite/cli/commands/provision.py", line 160, in up
    self.call(VagrantCommandActor('up'))
  File "/home/thalman/sssd-test-suite/cli/lib/command.py", line 71, in call
    self.runner.call(command, *args, **kwargs)
  File "/home/thalman/sssd-test-suite/cli/lib/command.py", line 229, in call
    self._run_handler(handler, args, argv)
  File "/home/thalman/sssd-test-suite/cli/lib/command.py", line 270, in _run_handler
    handler.run(args, argv)
  File "/home/thalman/sssd-test-suite/cli/commands/vagrant.py", line 55, in run
    guests = args.guests if 'all' not in args.guests else self.AllGuests

appears when running ./sssd-test-suite provision enroll all command

Adding args to  EnrollActor.call(VagrantCommandActor('up') fixes the issue